### PR TITLE
Properly truncate incoming messages from rpi

### DIFF
--- a/SAMD21/Rev B/RS485_STIR/RS485_STIR.ino
+++ b/SAMD21/Rev B/RS485_STIR/RS485_STIR.ino
@@ -27,19 +27,21 @@ void setup()
   SerialUSB.begin(9600);
   Serial1.begin(9600);
   // reserve 200 bytes for the inputString:
-  inputString.reserve(1000);
-  while (!Serial1);
+  inputString.reserve(2000);
   pinMode(12, OUTPUT);
   digitalWrite(12, LOW);
-  
+  while (!Serial1);
 }
 
 
 void loop() {
-  serialEvent(1);
+  serialEvent();
   if (stringComplete) {
     SerialUSB.println(inputString);
     in.analyzeAndCheck(inputString);
+
+    // Clear input string up to first "!", avoid accumulation of previous messages
+    inputString = "";
     
     if(in.addressFound){
       if (in.input_array[0] == "i" || in.input_array[0] == "r") {
@@ -61,7 +63,6 @@ void loop() {
         SerialUSB.println("Command Executed!");
         new_input = false;
       }
-
       inputString = "";
     }
     stringComplete = false;
@@ -103,7 +104,6 @@ void exec_stir()
   //Serial.println();
   
     while(Tlc.update());
-    serialEvent(12);
     
    // 10 settings for the stir rate
    for (int n = 0; n < 98; n++) { 
@@ -114,22 +114,16 @@ void exec_stir()
       }
     }
     while(Tlc.update());
-    serialEvent(1);
    }
-
-   serialEvent(70);
 }
 
-void serialEvent(int time_wait) {
-  for (int n=0; n<time_wait; n++) {
-      while (Serial1.available()) {
-        char inChar = (char)Serial1.read();
-        inputString += inChar;
-        if (inChar == '!') {
-          stringComplete = true;
-        }
-      }
-    delay(1);
+void serialEvent() {
+  while (Serial1.available()) {
+    char inChar = (char)Serial1.read();
+    inputString += inChar;
+    if (inChar == '!') {
+      stringComplete = true;
+      break;
+    }
   }
-  
 }

--- a/SAMD21/Rev B/RS485_TEMP/RS485_TEMP.ino
+++ b/SAMD21/Rev B/RS485_TEMP/RS485_TEMP.ino
@@ -69,8 +69,8 @@ void setup() {
   // initialize serial:
   Serial1.begin(9600);
   SerialUSB.begin(9600);
-  // reserve 1000 bytes for the inputString:
-  inputString.reserve(1000);
+  // reserve 2000 bytes for the inputString:
+  inputString.reserve(2000);
 
   while (!Serial1);
 
@@ -86,6 +86,9 @@ void loop() {
     SerialUSB.println(inputString);
     in.analyzeAndCheck(inputString);
 
+    // Clear input string, avoid accumulation of previous messages
+    inputString = "";
+
     if (in.addressFound) {
       if (in.input_array[0] == "i" || in.input_array[0] == "r") {
         
@@ -97,7 +100,6 @@ void loop() {
         SerialUSB.println("Responding with Data...");
         new_input = true;
         dataResponse();
-        
         SerialUSB.println("Waiting for OK to execute...");
       }
 
@@ -107,9 +109,9 @@ void loop() {
         new_input = false;
       }
 
-      inputString = "";
-      in.addressFound = false;
+    inputString = "";
     }
+    in.addressFound = false;
     stringComplete = false;
   }
   // Update PID every loop for better temp control
@@ -117,14 +119,14 @@ void loop() {
 }
 
 void serialEvent() {
-    while (Serial1.available()) {
-      char inChar = (char)Serial1.read();
-      inputString += inChar;
-      if (inChar == '!') {
-        stringComplete = true;
-      }
+  while (Serial1.available()) {
+    char inChar = (char)Serial1.read();
+    inputString += inChar;
+    if (inChar == '!') {
+      stringComplete = true;
+      break;
     }
-
+  }
 }
 
 


### PR DESCRIPTION
The input string is now truncated each time a full message has
arrived; previous behavior was the gradual increase in size of
`inputString`, until it was cleared, which might lead to truncation
of long messages and dropping of commands.

This change has been tested on all arduinos except the `PD` one. The
`STIR` arduino still seems to drop a command every ~10, so it
might need a few more tests to remove all possible corner cases, which
may be due to the `Serial1` messages overlapping.