### PR TITLE
Fix PWM timing misalignment

### DIFF
--- a/libraries/Tlc5490_SAMD/Tlc5940.cpp
+++ b/libraries/Tlc5490_SAMD/Tlc5940.cpp
@@ -178,7 +178,8 @@ void Tlc5940::init(uint8_t pwm_val, uint16_t initialValue)
   
   //Datasheet page 95
   // Initialize GCLK 
-  REG_GCLK_GENDIV = GCLK_GENDIV_DIV(3) |  // Divide the 48MHz clock source by divisor 1: 48MHz/1=48MHz
+  REG_GCLK_GENDIV = 
+    GCLK_GENDIV_DIV(TLC_GCLK_DIV) |       // Divide the 48MHz clock source by divisor : 48MHz/DIV
     GCLK_GENDIV_ID(4);                    // Select Generic Clock (GCLK) 4
   while (GCLK->STATUS.bit.SYNCBUSY);      // Wait for synchronization
 
@@ -247,7 +248,7 @@ void Tlc5940::init(uint8_t pwm_val, uint16_t initialValue)
     enable_GSCLK_2();                        // output on TCC0:7 //arduino pin 7
   }
 
-  REG_TCC1_CC0 = 16360;                      //set TCC1 interrupt timing
+  REG_TCC1_CC0 = TLC_PWM_PERIOD;             // set TCC1 interrupt timing
   while (TCC1->SYNCBUSY.bit.CC0);            // Wait for synchronization
 
   //Datasheet page 703
@@ -463,9 +464,9 @@ void tlc_shift8(uint8_t pwm_val, uint8_t byte)
   if(pwm_val & 0x1){
     for (uint8_t bit = 0x80; bit; bit >>= 1) {
       if (bit & byte) {
-  SIN_PORT_1 |= (1 << SIN_PIN_1);  // set SIN high (left PWM)
+        SIN_PORT_1 |= (1 << SIN_PIN_1);  // set SIN high (left PWM)
       } else {
-  SIN_PORT_1 &=~ (1 << SIN_PIN_1); // set SIN low (left PWM)
+        SIN_PORT_1 &=~ (1 << SIN_PIN_1); // set SIN low (left PWM)
       }
       pulse_pin(SCLK_PORT_1, SCLK_PIN_1);
     }

--- a/libraries/Tlc5490_SAMD/tlc_config.h
+++ b/libraries/Tlc5490_SAMD/tlc_config.h
@@ -61,7 +61,7 @@
     of the first TLC to the SIN (TLC pin 26) of the next.  The rest of the pins
     are attached normally.
     \note Each TLC needs it's own IREF resistor */
-#define NUM_TLCS    3
+#define NUM_TLCS    1
 
 /** Determines how data should be transfered to the TLCs.  Bit-banging can use
     any two i/o pins.
@@ -98,20 +98,37 @@
     Default is uint8_t, which supports up to 16 TLCs. */
 #define TLC_CHANNEL_TYPE    uint8_t
 
-/** Determines how long each PWM period should be, in clocks.
-    \f$\displaystyle f_{PWM} = \frac{f_{osc}}{2 * TLC\_PWM\_PERIOD} Hz \f$
-    \f$\displaystyle TLC\_PWM\_PERIOD = \frac{f_{osc}}{2 * f_{PWM}} \f$
-    This is related to TLC_GSCLK_PERIOD:
-    \f$\displaystyle TLC\_PWM\_PERIOD =
-       \frac{(TLC\_GSCLK\_PERIOD + 1) * 4096}{2} \f$
-    \note The default of 8192 means the PWM frequency is 976.5625Hz */
-#define TLC_PWM_PERIOD   16384 
 
-/** Determines how long each period GSCLK is.
-    This is related to TLC_PWM_PERIOD:
-    \f$\displaystyle TLC\_GSCLK\_PERIOD =
-       \frac{2 * TLC\_PWM\_PERIOD}{4096} - 1 \f$
-    \note Default is 3 */
-#define TLC_GSCLK_PERIOD    7
+/** -------------------- Timing configuration ---------------------------------
+    To achieve a target PWM frequency f, use the following equation:
+    
+        f = 48 MHz / (TLC_GCLK_DIV * TLC_PWM_PERIOD)
+
+    Don't forget to also set TLC_GSCLK_PERIOD accordingly:
+
+        TLC_GSCLK_PERIOD = (TLC_PWM_PERIOD / 4096) - 1 
+
+    Example configurations using full duty range of 0-4095
+    PWM frequency       TLC_GCLK_DIV    TLC_PWM_PERIOD      TLC_GSCLK_PERIOD
+    ~976 Hz             2               24576               5
+    ~5859 Hz            1               8192                1
+
+    WARNING: this high frequency config will only use duty levels 0-2047
+    PWM frequency       TLC_GCLK_DIV    TLC_PWM_PERIOD      TLC_GSCLK_PERIOD
+    ~11,719 Hz          1               4096                1               
+*/
+
+/** Sets the frequency of the general clock (GCLK) by dividing the 48 MHz 
+    system clock by the specified whole number factor. */
+#define TLC_GCLK_DIV        1
+
+/** Determines how long each PWM period should be, in cycles of the general
+    clock. */
+#define TLC_PWM_PERIOD      4096
+
+/** Determines the period of the grayscale clock (GSCLK) timer. The effective
+    period is (TLC_GSCLK_PERIOD + 1) cycles of the general clock. 
+    WARNING: The minimum value TLC_GSCLK_PERIOD can take is 1. */
+#define TLC_GSCLK_PERIOD    1
 
 #endif

--- a/libraries/Tlc5490_SAMD/tlc_config.h
+++ b/libraries/Tlc5490_SAMD/tlc_config.h
@@ -61,7 +61,7 @@
     of the first TLC to the SIN (TLC pin 26) of the next.  The rest of the pins
     are attached normally.
     \note Each TLC needs it's own IREF resistor */
-#define NUM_TLCS    1
+#define NUM_TLCS    3
 
 /** Determines how data should be transfered to the TLCs.  Bit-banging can use
     any two i/o pins.

--- a/libraries/Tlc5490_SAMD/tlc_config.h
+++ b/libraries/Tlc5490_SAMD/tlc_config.h
@@ -120,15 +120,15 @@
 
 /** Sets the frequency of the general clock (GCLK) by dividing the 48 MHz 
     system clock by the specified whole number factor. */
-#define TLC_GCLK_DIV        1
+#define TLC_GCLK_DIV        2
 
 /** Determines how long each PWM period should be, in cycles of the general
     clock. */
-#define TLC_PWM_PERIOD      4096
+#define TLC_PWM_PERIOD      24576
 
 /** Determines the period of the grayscale clock (GSCLK) timer. The effective
     period is (TLC_GSCLK_PERIOD + 1) cycles of the general clock. 
     WARNING: The minimum value TLC_GSCLK_PERIOD can take is 1. */
-#define TLC_GSCLK_PERIOD    1
+#define TLC_GSCLK_PERIOD    5
 
 #endif


### PR DESCRIPTION
Hi all, 

The goal of this PR is to address improperly configured timer behavior in the Tlc5490_SAMD library. As is, the default configuration of the library allows Arduino client code to access only half of the possible 12-bit duty cycle range (0-2047, rather than 0-4095), as is discussed in forum issue [345](https://www.evolver.bio/t/pwm-tlc5940-values-are-not-linear-and-saturate-midrange/345), and briefly in [205](https://www.evolver.bio/t/arduino-and-pwm-board-not-interacting-properly/205/5?u=jnurban).

Upon inspection of the library, I found that there was a hard-coded division factor of 3 in the general clock initialization code ([here](https://github.com/FYNCH-BIO/evolver-arduino/blob/a43ab7da51ce7d22df4276fc1df99b7c477db61c/libraries/Tlc5490_SAMD/Tlc5940.cpp#L181)). Additionally, as Dan Hart pointed out, the [compare register value](https://github.com/FYNCH-BIO/evolver-arduino/blob/a43ab7da51ce7d22df4276fc1df99b7c477db61c/libraries/Tlc5490_SAMD/Tlc5940.cpp#L250) (`REG_TCC1_CC0`) for timer 1 which controls PWM frequency was also set to a hard coded constant. Each of these issues made the timing configuration equations listed in [tlc_config.h](https://github.com/FYNCH-BIO/evolver-arduino/blob/a43ab7da51ce7d22df4276fc1df99b7c477db61c/libraries/Tlc5490_SAMD/tlc_config.h) incorrect as written. 

I refactored the clock division factor `TLC_GCLK_DIV` as a new configuration setting in tlc_config.h, and I set `REG_TCC1_CC0` to be equal to the `TLC_PWM_PERIOD` setting. I have rewritten the timing configuration equations in the comments of tlc_config.h, in addition to adding some example configurations for ease of setup by users needing to customize this behavior:

```cpp
/** -------------------- Timing configuration ---------------------------------
    To achieve a target PWM frequency f, use the following equation:
    
        f = 48 MHz / (TLC_GCLK_DIV * TLC_PWM_PERIOD)

    Don't forget to also set TLC_GSCLK_PERIOD accordingly:

        TLC_GSCLK_PERIOD = (TLC_PWM_PERIOD / 4096) - 1 

    Example configurations using full duty range of 0-4095
    PWM frequency       TLC_GCLK_DIV    TLC_PWM_PERIOD      TLC_GSCLK_PERIOD
    ~976 Hz             2               24576               5
    ~5859 Hz            1               8192                1

    WARNING: this high frequency config will only use duty levels 0-2047
    PWM frequency       TLC_GCLK_DIV    TLC_PWM_PERIOD      TLC_GSCLK_PERIOD
    ~11,719 Hz          1               4096                1               
*/

/** Sets the frequency of the general clock (GCLK) by dividing the 48 MHz 
    system clock by the specified whole number factor. */
#define TLC_GCLK_DIV        2

/** Determines how long each PWM period should be, in cycles of the general
    clock. */
#define TLC_PWM_PERIOD      24576

/** Determines the period of the grayscale clock (GSCLK) timer. The effective
    period is (TLC_GSCLK_PERIOD + 1) cycles of the general clock. 
    WARNING: The minimum value TLC_GSCLK_PERIOD can take is 1. */
#define TLC_GSCLK_PERIOD    5
```

Each timing configuration listed in those comments has so far been validated by oscilloscope measurements, with additional hardware validation testing planned for this coming week with the help of @nb-e and @ezirayw.

I also changed the `NUM_TLCS` setting from 3 to 1 to eliminate unnecessary serial clock cycles. In my limited understanding of common system setups, we're never daisy chaining multiple TLCs to be controlled by a single Arduino board, which means `NUM_TLCS` shouldn't ever need to be greater than 1. However, if this is incorrect we can switch the value back to 3.
