### PR TITLE
Added specific code to initialize right PWM in TLC5940 library

### DIFF
--- a/libraries/Tlc5490_SAMD/Tlc5940.cpp
+++ b/libraries/Tlc5490_SAMD/Tlc5940.cpp
@@ -175,6 +175,17 @@ void Tlc5940::init(uint8_t pwm_val, uint16_t initialValue)
   
   REG_TCC1_INTENSET |=  TCC_INTENSET_MC0; // set PWM interrupts
 
+  if (pos_2) {
+    // Force pins 7,8,9,10 to OUTPUT & LOW for right PWM board
+    pinMode(7, OUTPUT);
+    digitalWrite(7, LOW);
+    pinMode(8, OUTPUT);
+    digitalWrite(8, LOW);
+    pinMode(9, OUTPUT);
+    digitalWrite(9, LOW);
+    pinMode(10, OUTPUT);
+    digitalWrite(10, LOW);
+  }
   
   //Datasheet page 95
   // Initialize GCLK 


### PR DESCRIPTION
Needed to add this code to the TLC5940 library or right PWM would not initialize properly. I (and chatGPT) did not see any issues in the code that might necessitate this. Attempts to do this the "clean" way using the following code failed:

```
if (pos_2) {
    // Make sure right pins are outputs and definitely driven LOW 
    SCLK_DDR_2 |= (1 << SCLK_PIN_2);
    SCLK_PORT_2 &= ~(1 << SCLK_PIN_2);

    SIN_DDR_2  |= (1 << SIN_PIN_2);
    SIN_PORT_2 &= ~(1 << SIN_PIN_2);

    XLAT_DDR_2 |= (1 << XLAT_PIN_2);
    XLAT_PORT_2 &= ~(1 << XLAT_PIN_2);  // or HIGH, if that’s how left side does it

    BLANK_DDR_2 |= (1 << BLANK_PIN_2);
    BLANK_PORT_2 |= (1 << BLANK_PIN_2); // many designs start BLANK high
}
```